### PR TITLE
Make crashkernel size configurable with reasonable defaults

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,11 +18,13 @@
 #
 class crashdump::config {
 
+  $crashkernel_size = $crashdump::crashkernel_size
+
   case $::osfamily {
     'RedHat' : {
       # XXX this will need an onlyif =>
       exec { 'update grub config':
-        command  => 'grubby --update-kernel=ALL --args="crashkernel=128M"',
+        command  => "grubby --update-kernel=ALL --args=\"crashkernel=${crashkernel_size}\"",
         pwd      => '/',
         path     => '/sbin:/bin:/usr/bin:/usr/sbin',
         provider => 'posix',
@@ -39,10 +41,10 @@ class crashdump::config {
         # way of managing a single part of a single line in a configuration file
         # or any sensible hooks for grub that everyone uses, we keep it simple.
         'Ubuntu' : {
-          file_line { 'crashkernel=128M':
+          file_line { 'crashkernel_size':
             path  => '/etc/grub.d/10_linux',
             match => '    GRUB_CMDLINE_EXTRA="\$GRUB_CMDLINE_EXTRA crashkernel=.*',
-            line  => '    GRUB_CMDLINE_EXTRA="$GRUB_CMDLINE_EXTRA crashkernel=128M"',
+            line  => "    GRUB_CMDLINE_EXTRA=\"\$GRUB_CMDLINE_EXTRA crashkernel=${crashkernel_size}\"",
           }
         }
         default : {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,9 @@
 #
 # Copyright 2013 Brainsware
 #
-class crashdump {
+class crashdump (
+  $crashkernel_size = $crashdump::params::crashkernel_size,
+) inherits crashdump::params {
 
   anchor { 'crashdump::begin': } ->
   class { 'crashdump::config': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -28,4 +28,16 @@ class crashdump::params {
   $service_enable =  true
   $service_ensure = 'running'
 
+  # These rounded numbers (1800, 3800, ...) are based on the values of
+  # memorysize_mb on systems that nominally have 2GB, 4GB, ... of RAM. 
+  
+  # XXX: This logic might be slightly flawed because memorysize_mb shrinks by
+  # the amount of reserved memory for the crashkernel.
+  if $::memorysize_mb <= 1800 {
+    $crashkernel_size = '128M'
+  } elsif $::memorysize_mb > 1800 and $::memorysize_mb <= 3800 {
+    $crashkernel_size = '256M'
+  } elsif $::memorysize_mb > 3800 {
+    $crashkernel_size = '512M'
+  } # ... this might need to be extended for systems with even more memory.
 }


### PR DESCRIPTION
Add a class parameter `crashdump::crashkernel_size` that can be set by
the user. Its default value is based on `$::memorysize_mb`: for systems
with less than 2GB of memory crashkernel=128M is enough, for systems
with 2GB to 4GB we need crashkernel=256M and for systems with more than
4GB crashkernel=512M. This might need to be extended for systems with
even more memory.

This logic might be flawed for systems with "weird" amounts of memory,
and because `$::memorysize_mb` shrinks by the amount of reserved
crashkernel memory, possibly causing a flip-flop effect when setting the
crashkernel size.

Addresses #3.