### PR TITLE
Fix crashdump service restarting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,16 +19,29 @@
 class crashdump (
   $package_name   = $::crashdump::params::package_name,
   $package_ensure = $::crashdump::params::package_ensure,
-  $service_name   = $::crashdump::service_name,
-  $service_enable = true,
-  $service_ensure = 'running',
+  $service_name   = $::crashdump::params::service_name,
+  $service_enable = $::crashdump::params::service_enable,
+  $service_ensure = $::crashdump::params::service_ensure,
   $crashkernel_size = $crashdump::params::crashkernel_size,
 ) inherits crashdump::params {
 
+  include 'crashdump::install'
+  include 'crashdump::config'
+  include 'crashdump::service'
+
   anchor { 'crashdump::begin': } ->
-  class { 'crashdump::config': } ->
-  class { 'crashdump::install': } ->
-  class { 'crashdump::service': } ->
-  anchor { 'crashdump::end':}
+  Class['crashdump::install'] ->
+  Class['crashdump::config'] ->
+  Class['crashdump::service'] ->
+  anchor { 'crashdump::end': }
+
+  Class['crashdump::install']
+  -> Class['crashdump::config']
+
+  Class['crashdump::install']
+  ~> Class['crashdump::service']
+
+  Class['crashdump::config']
+  ~> Class['crashdump::service']
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -20,10 +20,13 @@ class crashdump::params {
     'RedHat' => [ 'crash', 'kexec-tools' ],
   }
 
+  # This is not a running service, it just loads the crash kernel
+  $service_ensure = undef
   $service_name   = $::lsbdistcodename? {
     'trusty' => 'kexec-load',
     default  => 'kdump',
   }
+  $service_enable = true
 
   # These rounded numbers (1800, 3800, ...) are based on the values of
   # memorysize_mb on systems that nominally have 2GB, 4GB, ... of RAM. 


### PR DESCRIPTION
The crashdump service (kdump) is not a running service but should be
started only once (on boot and after package installation) to load the
crash kernel. Thus set `ensure => undef` and `enable => true` for
`Service[crashdump]` and let `crashdump::install` and
`crashdump::config` notify the service when needed.