### PR TITLE
Don't compare strings with integers

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,15 +29,15 @@ class crashdump::params {
   $service_enable = true
 
   # These rounded numbers (1800, 3800, ...) are based on the values of
-  # memorysize_mb on systems that nominally have 2GB, 4GB, ... of RAM. 
-  
+  # memorysize_mb on systems that nominally have 2GB, 4GB, ... of RAM.
+
   # XXX: This logic might be slightly flawed because memorysize_mb shrinks by
   # the amount of reserved memory for the crashkernel.
-  if $::memorysize_mb <= 1800 {
+  if $::memorysize_mb <= '1800' {
     $crashkernel_size = '128M'
-  } elsif $::memorysize_mb > 1800 and $::memorysize_mb <= 3800 {
+  } elsif $::memorysize_mb > '1800' and $::memorysize_mb <= '3800' {
     $crashkernel_size = '256M'
-  } elsif $::memorysize_mb > 3800 {
+  } elsif $::memorysize_mb > '3800' {
     $crashkernel_size = '512M'
   } # ... this might need to be extended for systems with even more memory.
 }


### PR DESCRIPTION
Quote integers in params.pp when comparing them with fact values (which
are strings). This should satisfy the future parser and make this module
compatible with Puppet 4.