### PR TITLE
Update Grub after config changes on Ubuntu

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -44,9 +44,10 @@ class crashdump::config {
               # way of managing a single part of a single line in a configuration file
               # or any sensible hooks for grub that everyone uses, we keep it simple.
               file_line { 'crashkernel_size':
-                path  => '/etc/grub.d/10_linux',
-                match => '    GRUB_CMDLINE_EXTRA="\$GRUB_CMDLINE_EXTRA crashkernel=.*',
-                line  => "    GRUB_CMDLINE_EXTRA=\"\$GRUB_CMDLINE_EXTRA crashkernel=${crashkernel_size}\"",
+                path   => '/etc/grub.d/10_linux',
+                match  => '    GRUB_CMDLINE_EXTRA="\$GRUB_CMDLINE_EXTRA crashkernel=.*',
+                line   => "    GRUB_CMDLINE_EXTRA=\"\$GRUB_CMDLINE_EXTRA crashkernel=${crashkernel_size}\"",
+                notify => Class['::crashdump::update_grub'],
               }
             }
             '14.04' : {
@@ -63,6 +64,7 @@ class crashdump::config {
                 group   => 'root',
                 mode    => '0644',
                 content => template("${module_name}/kexec-tools.cfg.erb"),
+                notify  => Class['::crashdump::update_grub'],
               }
 
               # Need to enable the use of kdump. This requires a reboot, of course.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,6 +28,7 @@ class crashdump (
   include 'crashdump::install'
   include 'crashdump::config'
   include 'crashdump::service'
+  include 'crashdump::update_grub'
 
   anchor { 'crashdump::begin': } ->
   Class['crashdump::install'] ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -40,4 +40,9 @@ class crashdump::params {
   } elsif $::memorysize_mb > '3800' {
     $crashkernel_size = '512M'
   } # ... this might need to be extended for systems with even more memory.
+
+  $update_grub_cmd = $::operatingsystem ? {
+    'Ubuntu' => '/usr/sbin/update-grub',
+    default  => undef
+  }
 }

--- a/manifests/update_grub.pp
+++ b/manifests/update_grub.pp
@@ -1,0 +1,12 @@
+class crashdump::update_grub {
+
+  # This only works on Ubuntu (and possibly Debian)
+  if $::operatingsystem == 'Ubuntu' {
+    exec { 'update-grub':
+      command     => $::crashdump::params::update_grub_cmd,
+      refreshonly => true,
+      provider    => 'posix',
+    }
+  }
+
+}


### PR DESCRIPTION
Introduce a class crashdump::update_grub with an exec resource that
calls /usr/sbin/update-grub on Ubuntu systems. Notify this class when
changes to the managed Grub config files or file entries happen.