### PR TITLE
Update memorysize thresholds for crashkernel size determination

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,9 +33,9 @@ class crashdump::params {
 
   # XXX: This logic might be slightly flawed because memorysize_mb shrinks by
   # the amount of reserved memory for the crashkernel.
-  if $::memorysize_mb <= '1800' {
+  if $::memorysize_mb <= '1600' {
     $crashkernel_size = '128M'
-  } elsif $::memorysize_mb > '1800' and $::memorysize_mb <= '3800' {
+  } elsif $::memorysize_mb > '1600' and $::memorysize_mb <= '3800' {
     $crashkernel_size = '256M'
   } elsif $::memorysize_mb > '3800' {
     $crashkernel_size = '512M'


### PR DESCRIPTION
As mentioned in a comment in params.pp the memorysize_mb shrinks by the
amount of reserved memory for the crashkernel.

The used memorysize_mb threshhold of 1800 is problematic if you use a
memorysize of 2 GB on your system (and that's a pretty common setting)
because the crashkernel_size will flap between 128M and 256M after each
reboot.

Here's the math:

If crashkernel_size is set to 256M memorysize_mb is 1745 and therefore
with next reboot the crashkernel_size is set to 128M. Then the
memorysize_mb is 1873 and on next reboot the crashkernel_size is set
again to 256M and so on.